### PR TITLE
Save Static Entries Enabled status in the config file.

### DIFF
--- a/src/dns-server/dns-client/index.js
+++ b/src/dns-server/dns-client/index.js
@@ -50,7 +50,7 @@ class DnsClient {
 	saveServersListToConfig() {
 		const serversToSave = {};
 
-		Object.keys( this.serversList ).map( ( server )=> {
+		Object.keys( this.serversList ).map( ( server ) => {
 			const serverConfig = this.serversList[ server ];
 
 			if ( false !== serverConfig.permanent ) {
@@ -170,7 +170,7 @@ class DnsClient {
 
 	updateStaticEntriesForHost( host ) {
 		if ( this.staticEntries[ host ] ) {
-			Object.keys( this.staticEntries[ host ] ).map( ( entryType )=> {
+			Object.keys( this.staticEntries[ host ] ).map( ( entryType ) => {
 				const entry = this.staticEntries[ host ][ entryType ];
 				this.dnsCache.addStaticEntry( entry );
 			} );
@@ -196,21 +196,27 @@ class DnsClient {
 	loadStaticEntriesFromConfig() {
 		this.staticEntries = configManager.get( 'client:staticEntries' ) || {};
 
-		Object.keys( this.staticEntries ).map( ( host )=> {
-			const entry = this.staticEntries[ host ];
+		if ( this.isStaticEntriesEnabled() ) {
+			Object.keys( this.staticEntries ).map( ( host ) => {
+				const entry = this.staticEntries[ host ];
 
-			Object.keys( entry ).map( ( entryType )=> {
-				this.addStaticEntry( entry[ entryType ], true );
+				Object.keys( entry ).map( ( entryType ) => {
+					this.addStaticEntry( entry[ entryType ], true );
+				} );
 			} );
-		} );
+		}
 	}
 
 	saveStaticEntriesToConfig() {
 		configManager.set( 'client:staticEntries', this.staticEntries );
 	}
 
+	isStaticEntriesEnabled() {
+		return configManager.get( 'client:staticEntriesEnabled' ) || false;
+	}
+
 	staticEntriesEnable() {
-		this.staticEntriesEnabled = true;
+		configManager.set( 'client:staticEntriesEnabled', true );
 		Object.keys( this.staticEntries ).map( ( host ) => {
 			this.updateStaticEntriesForHost( host );
 		} );
@@ -220,7 +226,7 @@ class DnsClient {
 		Object.keys( this.staticEntries ).map( ( host ) => {
 			this.dnsCache.removeStaticEntry( host );
 		} );
-		this.staticEntriesEnabled = false;
+		configManager.set( 'client:staticEntriesEnabled', false );
 	}
 }
 

--- a/src/dns-server/websocket-server/events/config.js
+++ b/src/dns-server/websocket-server/events/config.js
@@ -29,7 +29,7 @@ module.exports = {
 	},
 
 	getStaticEntriesStatus( socket ) {
-		socket.emit( 'config:StaticEntriesStatus', { status: this.dnsClient.staticEntriesEnabled } );
+		socket.emit( 'config:StaticEntriesStatus', { status: this.dnsClient.isStaticEntriesEnabled() } );
 	},
 
 	disableStaticEntries( socket ) {


### PR DESCRIPTION
Previously the Static Entries status wasn't saved an was always enabled when first starting `HostsBeGone`.

This caused some problems since you had to manually go and disable the static entries every time the server started, which was an inconvenience.