### PR TITLE
Servers List: Restore labels in the list

### DIFF
--- a/src/web-client/src/components/common/entry-list/entry.jsx
+++ b/src/web-client/src/components/common/entry-list/entry.jsx
@@ -36,7 +36,10 @@ class EntryListEntry extends React.Component {
 			);
 		}
 
-		return null;
+		// If it is a simple entry, just show the label
+		return (
+			<div className="entry-list-entry__value">{ this.props.entry.label }</div>
+		);
 	}
 
 	render = () => {


### PR DESCRIPTION
With simplifying the Entry List component, I accidentally the labels. This restores them to their former glory.