### PR TITLE
Do not crash the server on malformed DNS requests or responses.

### DIFF
--- a/src/dns-server/dns-server/index.js
+++ b/src/dns-server/dns-server/index.js
@@ -40,8 +40,11 @@ class DnsServer {
 			} );
 
 			console.log( 'Query Result: ', JSON.stringify( result ) );
-
-			response.send();
+			try {
+				response.send();
+			} catch (e) {
+				console.log( 'Exception!', e );
+			}
 		} );
 	}
 

--- a/src/dns-server/dns-server/index.js
+++ b/src/dns-server/dns-server/index.js
@@ -42,7 +42,7 @@ class DnsServer {
 			console.log( 'Query Result: ', JSON.stringify( result ) );
 			try {
 				response.send();
-			} catch (e) {
+			} catch ( e ) {
 				console.log( 'Exception!', e );
 			}
 		} );


### PR DESCRIPTION
Some DNS servers that are a part of a captive portals on public networks send malformed DNS packets until the user manages to get through the activation process.

Since the thrown error wasn't handled, this crashed the DNS server.

This PR adds rudimentary error handling for exceptions in the DNS package formatting.