### PR TITLE
Install as a system service

### DIFF
--- a/dns-server.js
+++ b/dns-server.js
@@ -1,5 +1,6 @@
-const dnsClient = require('./src/dns-server/dns-client');
-const dnsServer = require( './src/dns-server/dns-server' );
-new dnsClient( ( clientInstance )=> {
-	new dnsServer( clientInstance );
+const DNSClient = require( './src/dns-server/dns-client' );
+const DNSServer = require( './src/dns-server/dns-server' );
+
+new DNSClient( ( clientInstance )=> {
+	new DNSServer( clientInstance );
 } );

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash": "^4.17.2",
     "native-dns": "github:tutosfaciles48/node-dns",
     "nconf": "^0.8.4",
+    "node-mac": "^0.1.8",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-jsonschema-form": "^0.41.1",

--- a/start.js
+++ b/start.js
@@ -1,5 +1,15 @@
+const Service = require( 'node-mac' ).Service;
+const path = require( 'path' );
+
+try {
+	process.chdir( __dirname );
+} catch ( e ) {
+	console.error( 'Unable to change directory, still in: ', process.cwd() );
+}
+
 const spawn = require( 'child_process' ).spawn;
 const osx = require( './src/platform-specific/macos' );
+
 let serverProcess = null;
 let clientProcess = null;
 
@@ -14,6 +24,17 @@ function get_user_id() {
 		return sudo_uid;
 	}
 
+	/**
+	 * TODO: TEMPORARY! Runs the server as the first user in OS X.
+	 *
+	 * This will be improved later, when a proper service install code is put in place.
+	 * It should save the ID of the user that installed the service in the config file.
+	 *
+	 * Another possible solution is to check who's the owner of the folder the script is in and
+	 * run as this user.
+ 	 */
+	return 501;
+
 	return process.getuid();
 }
 
@@ -21,8 +42,8 @@ function startDNSserver() {
 	osx.takeOverDNSServers();
 	osx.resetFirewallRules();
 	osx.addPortForwarding( 53, 15553 );
-
-	const dnsServerProcess = spawn( 'node', [ './dns-server.js' ], {
+	console.log( process.cwd() );
+	const dnsServerProcess = spawn( process.argv[ 0 ], [ path.join( __dirname, 'dns-server.js' ) ], {
 		cwd: process.cwd(),
 		uid: get_user_id()
 	} );
@@ -41,11 +62,19 @@ function startDNSserver() {
 		startDNSserver();
 	} );
 
+	dnsServerProcess.on( 'error', ( err ) => {
+		console.log( 'SERVER ERROR: ', err );
+	} );
+
+	dnsServerProcess.on( 'uncaughtException', ( ex ) => {
+		console.log( 'SERVER UNCAUGHT EXCEPTION: ', ex );
+	} );
+
 	return dnsServerProcess;
 }
 
 function startWebClient() {
-	const webClientProcess = spawn( 'node', [ './web-client.js' ], {
+	const webClientProcess = spawn( process.argv[ 0 ], [ './web-client.js' ], {
 		cwd: process.cwd(),
 		uid: get_user_id()
 	} );
@@ -73,16 +102,47 @@ if ( ! is_root() ) {
 function stopServer() {
 	osx.resetFirewallRules();
 	osx.restoreOriginalDNSServers();
-
-	serverProcess.kill( 'SIGTERM' );
-	clientProcess.kill( 'SIGTERM' );
+	if ( serverProcess ) {
+		serverProcess.kill( 'SIGTERM' );
+	}
+	if ( clientProcess ) {
+		clientProcess.kill( 'SIGTERM' );
+	}
 
 	process.exit();
 }
 
-process.on( 'SIGINT', stopServer );
-process.on( 'SIGHUP', stopServer );
-process.on( 'SIGTERM', stopServer );
+function initServers() {
+	process.on( 'SIGINT', stopServer );
+	process.on( 'SIGHUP', stopServer );
+	process.on( 'SIGTERM', stopServer );
 
-serverProcess = startDNSserver();
-clientProcess = startWebClient();
+	process.on( 'uncaughtException', ( ex ) => {
+		console.error( 'PARENT Uncaught exception: ', ex );
+	} );
+
+	serverProcess = startDNSserver();
+	clientProcess = startWebClient();
+}
+
+const dnsService = new Service( {
+	name: 'Hosts Be Gone',
+	description: 'A local DNS server.',
+	script: path.join( __dirname, 'start.js' ),
+	wait: 2,
+	grow: .5,
+	maxRetries: 2,
+} );
+
+dnsService.on( 'install', () => {
+	dnsService.start();
+} );
+
+dnsService.on( 'start', initServers );
+dnsService.on( 'stop', stopServer );
+
+if ( ! dnsService.exists ) {
+	dnsService.install();
+} else {
+	dnsService.start();
+}

--- a/start.js
+++ b/start.js
@@ -42,7 +42,7 @@ function startDNSserver() {
 	osx.takeOverDNSServers();
 	osx.resetFirewallRules();
 	osx.addPortForwarding( 53, 15553 );
-	console.log( process.cwd() );
+
 	const dnsServerProcess = spawn( process.argv[ 0 ], [ path.join( __dirname, 'dns-server.js' ) ], {
 		cwd: process.cwd(),
 		uid: get_user_id()


### PR DESCRIPTION
Currently, the server had to be run on every startup in order to get resolving working. Since it wasn't installed as a service, it often was killed before being able to restore DNS servers to their old values. This caused no DNS server responding on bootup of the system.

This PR adds the option to install the server as a system service.

At the current implementation it tries to install it on every run, if it's not installed. Future updates will allow the option to run it without installing and to install it with a command line parameter.